### PR TITLE
Use travis deploy provider for gh-pages for javadoc deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,13 @@ script:
 - "./src/ci/build.sh"
 after_success:
   - bash <(curl -s https://codecov.io/bash) -f verifier/target/jacoco.exec
+
+deploy:
+  - provider: pages
+    skip_cleanup: true
+    github_token: $GH_API_KEY
+    local_dir: target/gh-pages
+    email: developers@okta.com
+    name: Travis CI - Auto Doc Build
+    on:
+      branch: master

--- a/pom.xml
+++ b/pom.xml
@@ -41,41 +41,4 @@
         <module>verifier</module>
         <module>examples</module>
     </modules>
-
-    <profiles>
-        <profile>
-            <id>pub-docs</id>
-            <build>
-
-                <!-- this needs to be fixed in the parent pom -->
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-scm-publish-plugin</artifactId>
-                            <version>1.1</version>
-                            <configuration>
-                                <checkinComment>Publishing javadoc for ${project.artifactId}:${project.version}</checkinComment>
-                                <content>${gh-pages.dir}</content>
-                                <skipDeletedFiles>true</skipDeletedFiles>
-                                <pubScmUrl>scm:git:https://${github.api.key}@github.com/${github.slug}.git</pubScmUrl>
-                                <scmBranch>gh-pages</scmBranch> <!-- branch with static site -->
-                                <checkoutDirectory>${project.build.directory}/scmpublish-checkout-javadoc</checkoutDirectory>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-                <!-- end fix in parent -->
-
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-scm-publish-plugin</artifactId>
-                        <version>1.1</version>
-                        <inherited>false</inherited>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/src/ci/build.sh
+++ b/src/ci/build.sh
@@ -34,9 +34,8 @@ else
         $MVN_CMD deploy -Pci
 
         # also deploy the javadocs to the site
-        git config --global user.email "developers@okta.com"
-        git config --global user.name "travis-ci Auto Doc Build"
-        $MVN_CMD javadoc:aggregate scm-publish:publish-scm -Ppub-docs -Pci
+        git clone -b gh-pages https://github.com/${REPO_SLUG}.git target/gh-pages/
+        $MVN_CMD javadoc:aggregate -Ppub-docs -Pc
     else
         # else try to run the ITs if possible (for someone who has push access to the repo
         if [ "$RUN_ITS" = true ] ; then


### PR DESCRIPTION
Move the SCM logic for gh-pages out of Maven pom and let Travis handle it post build