### PR TITLE
Public key URL not resolved correctly

### DIFF
--- a/verifier/src/main/java/com/okta/jwt/JwtHelper.java
+++ b/verifier/src/main/java/com/okta/jwt/JwtHelper.java
@@ -78,8 +78,8 @@ public final class JwtHelper {
         ConfigurationValidator.assertIssuer(issuerUrl);
         notEmpty(audience, "Audience cannot be empty");
 
-        // Keys URI can be hard codeded to avoid an extra call to the discovery endpoint
-        URL keysURI = URI.create(issuerUrl).resolve("/v1/keys").toURL();
+        // Keys URI can be hard coded to avoid an extra call to the discovery endpoint
+        URL keysURI = URI.create(issuerUrl + "/v1/keys").toURL();
 
         // Set up a JWT processor to parse the tokens and then check their signature
         // and validity time window (bounded by the "iat", "nbf" and "exp" claims)


### PR DESCRIPTION
The previous version introduced a change that removed the need for a discovery call to find the keys endpoint.
However the concatenation of `issuerUrl + "/v1/keys"` was invalid. This path was mock/spy to avoid making a live call to the discovery endpoint.

This change removes the mock/spy (no longer needed), and adds a test to verify the keys URL is set to the expected `issueUrl + "/v1/keys"`

Fixes: #26