### PR TITLE
Correct README code example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-- oraclejdk8
+- openjdk8
 - openjdk11
 
 addons:

--- a/README.md
+++ b/README.md
@@ -37,16 +37,20 @@ For validating a JWT, you will need a few different items:
 
 # Setting up the Library
 
-The Okta JWT Verifier can created via a fluent `JwtHelper` class:
+The Okta JWT Verifier can created via a fluent `JwtVerifiers` class:
 
+[//]: # (NOTE: code snippets in this README are updated automatically via a Maven plugin by running: mvn okta-code-snippet:snip)
+ 
+[//]: # (method: basicUsage)
 ```java
 AccessTokenVerifier jwtVerifier = JwtVerifiers.accessTokenVerifierBuilder()
-      .setIssuer("https://{yourOktaDomain}/oauth2/default")
-      .setAudience("api://default")      // defaults to 'api://default'
-      .setConnectionTimeout(1000) // defaults to 1000ms
-      .setReadTimeout(1000)       // defaults to 1000ms
-      .build();
+    .setIssuer("https://{yourOktaDomain}/oauth2/default")
+    .setAudience("api://default")                // defaults to 'api://default'
+    .setConnectionTimeout(Duration.ofSeconds(1)) // defaults to 1s
+    .setReadTimeout(Duration.ofSeconds(1))       // defaults to 1s
+    .build();
 ```
+[//]: # (end: basicUsage)
 
 This helper class configures a JWT parser with the details found via the [OpenID Connect discovery endpoint](https://openid.net/specs/openid-connect-discovery-1_0.html).  The public keys used to validate the JWTs will also be retrieved 
 and cached automatically.

--- a/examples/quickstart/src/main/java/com/okta/jwt/example/ReadmeSnippets.java
+++ b/examples/quickstart/src/main/java/com/okta/jwt/example/ReadmeSnippets.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.jwt.example;
+
+import com.okta.jwt.AccessTokenVerifier;
+import com.okta.jwt.JwtVerifiers;
+
+import java.time.Duration;
+
+/**
+ * Example snippets used for this projects README.md.
+ * <p>
+ * Manually run {@code mvn okta-code-snippet:snip} after changing this file to update the README.md.
+ */
+@SuppressWarnings({"unused"})
+public class ReadmeSnippets {
+
+    private void basicUsage() {
+        AccessTokenVerifier jwtVerifier = JwtVerifiers.accessTokenVerifierBuilder()
+            .setIssuer("https://{yourOktaDomain}/oauth2/default")
+            .setAudience("api://default")                // defaults to 'api://default'
+            .setConnectionTimeout(Duration.ofSeconds(1)) // defaults to 1s
+            .setReadTimeout(Duration.ofSeconds(1))       // defaults to 1s
+            .build();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -86,4 +86,17 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.okta</groupId>
+                    <artifactId>okta-code-snippet-maven-plugin</artifactId>
+                    <configuration>
+                        <sourceFile>examples/quickstart/src/main/java/com/okta/jwt/example/ReadmeSnippets.java</sourceFile>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/src/findbugs/findbugs-exclude.xml
+++ b/src/findbugs/findbugs-exclude.xml
@@ -15,4 +15,7 @@
   -->
 <FindBugsFilter>
 
+    <!-- ReadmeSnippets is formatted as an example, so there is dead code -->
+    <Match><Class name="com.okta.jwt.example.ReadmeSnippets"/></Match>
+
 </FindBugsFilter>


### PR DESCRIPTION
- uses the `okta-code-snippet:snip` maven plugin to ensure the code compiles

Fixes: #47