### PR TITLE
Add synk:monitor to travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,11 @@ after_success:
 - bash <(curl -s https://codecov.io/bash) -f verifier/target/site/jacoco/jacoco.xml
 
 deploy:
+- provider: script
+  script: ./mvnw snyk:monitor
+  on:
+    jdk: openjdk8
+    branch: master
 - provider: pages
   skip_cleanup: true
   github_token: $GH_API_KEY
@@ -30,6 +35,6 @@ deploy:
   email: developers@okta.com
   name: Travis CI - Auto Doc Build
   on:
-    jdk: oraclejdk8
+    jdk: openjdk8
     branch: master
     condition: "$TRAVIS_EVENT_TYPE != cron"

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta</groupId>
         <artifactId>okta-parent</artifactId>
-        <version>16</version>
+        <version>17</version>
     </parent>
 
     <groupId>com.okta.jwt</groupId>


### PR DESCRIPTION
This will _correctly_ set the dependency information for this project on snyk.io (only on master building with jdk8)