### PR TITLE
Added possibility of configuring the SSL parameters for API retrieval

### DIFF
--- a/api/src/main/java/com/okta/jwt/VerifierBuilderSupport.java
+++ b/api/src/main/java/com/okta/jwt/VerifierBuilderSupport.java
@@ -15,6 +15,9 @@
  */
 package com.okta.jwt;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
 import java.time.Duration;
 
 /**
@@ -57,6 +60,30 @@ public interface VerifierBuilderSupport<B extends VerifierBuilderSupport, R> {
      * @return a reference to the current builder for use in method chaining
      */
     B setReadTimeout(Duration readTimeout);
+
+    /**
+     * Sets the {@code sslSocketFactory} for the verifier.
+     *
+     * @param sslSocketFactory ssl socket factory
+     * @return a reference to the current builder for use in method chaining
+     */
+    B setSslSocketFactory(SSLSocketFactory sslSocketFactory);
+
+    /**
+     * Sets the {@code trustManager} for the verifier.
+     *
+     * @param trustManager ssl trust manager
+     * @return a reference to the current builder for use in method chaining
+     */
+    B setTrustManager(X509TrustManager trustManager);
+
+    /**
+     * Sets the {@code hostnameVerifier} for the verifier.
+     *
+     * @param hostnameVerifier hostname verifier
+     * @return a reference to the current builder for use in method chaining
+     */
+    B setHostnameVerifier(HostnameVerifier hostnameVerifier);
 
     /**
      * Constructs a JWT Verifier.

--- a/impl/src/main/java/com/okta/jwt/impl/http/OkHttpClient.java
+++ b/impl/src/main/java/com/okta/jwt/impl/http/OkHttpClient.java
@@ -20,6 +20,9 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -40,13 +43,27 @@ public class OkHttpClient implements HttpClient {
     private final okhttp3.OkHttpClient client;
 
     public OkHttpClient(Duration connectionTimeout, Duration readTimeout) {
+        this(connectionTimeout, readTimeout, null, null, null);
+    }
 
-        client = new okhttp3.OkHttpClient.Builder()
+    public OkHttpClient(Duration connectionTimeout, Duration readTimeout,
+                        SSLSocketFactory sslSocketFactory, X509TrustManager trustManager,
+                        HostnameVerifier hostnameVerifier) {
+
+        okhttp3.OkHttpClient.Builder clientBuilder = new okhttp3.OkHttpClient.Builder()
                 .connectTimeout(connectionTimeout.toMillis(), TimeUnit.MILLISECONDS)
                 .readTimeout(readTimeout.toMillis(), TimeUnit.MILLISECONDS)
                 .writeTimeout(readTimeout.toMillis(), TimeUnit.MILLISECONDS)
-                .retryOnConnectionFailure(true)
-                .build();
+                .retryOnConnectionFailure(true);
+
+        if (sslSocketFactory != null && trustManager != null) {
+            clientBuilder.sslSocketFactory(sslSocketFactory, trustManager);
+        }
+        if (hostnameVerifier != null) {
+            clientBuilder.hostnameVerifier(hostnameVerifier);
+        }
+
+        client = clientBuilder.build();
 
     }
 


### PR DESCRIPTION
During our integrations with a third party company, we have had some issues due to the fact that their server used a self-signed SSL certificate.

In this pull request, I have added the ability to configure explicitly the objects used by OkHttp to avoid validation of SSL certificates. It is obviously an optional feature and should cause no regression.
I have tried to follow the same code style used in the existing classes.

I've also sent by email the signed CLA.