### PR TITLE
Update dependencies to latest minor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[<img src="https://devforum.okta.com/uploads/oktadev/original/1X/bf54a16b5fda189e4ad2706fb57cbb7a1e5b8deb.png" align="right" width="256px"/>](https://devforum.okta.com/)
+[<img src="https://aws1.discourse-cdn.com/standard14/uploads/oktadev/original/1X/0c6402653dfb70edc661d4976a43a46f33e5e919.png" align="right" width="256px"/>](https://devforum.okta.com/)
 [![Maven Central](https://img.shields.io/maven-central/v/com.okta.jwt/okta-jwt-verifier.svg)](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.okta.jwt%22%20a%3A%22okta-jwt-verifier%22)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Support](https://img.shields.io/badge/support-Developer%20Forum-blue.svg)](https://devforum.okta.com/)

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -51,20 +51,29 @@
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-api</artifactId>
-            <version>0.10.7</version>
+            <version>${jjwt.version}</version>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-impl</artifactId>
-            <version>0.10.7</version>
+            <version>${jjwt.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-jackson</artifactId>
-            <version>0.10.7</version>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>

--- a/impl/src/test/groovy/com/okta/jwt/impl/jjwt/JjwtAccessTokenVerifierTest.groovy
+++ b/impl/src/test/groovy/com/okta/jwt/impl/jjwt/JjwtAccessTokenVerifierTest.groovy
@@ -15,6 +15,7 @@
  */
 package com.okta.jwt.impl.jjwt
 
+import com.okta.commons.lang.Classes
 import com.okta.jwt.Jwt
 import com.okta.jwt.JwtVerificationException
 import com.okta.jwt.impl.TestUtil
@@ -22,7 +23,7 @@ import io.jsonwebtoken.JwtBuilder
 import io.jsonwebtoken.SignatureAlgorithm
 import io.jsonwebtoken.SigningKeyResolver
 import io.jsonwebtoken.impl.DefaultClaims
-import io.jsonwebtoken.io.JacksonSerializer
+import io.jsonwebtoken.io.Serializer
 import org.testng.annotations.DataProvider
 import org.testng.annotations.Test
 
@@ -87,7 +88,7 @@ class JjwtAccessTokenVerifierTest extends TokenVerifierTestSupport{
 
     @Override
     byte[] defaultFudgedBody() {
-        JacksonSerializer serializer = new JacksonSerializer()
+        Serializer serializer = Classes.loadFromService(Serializer)
         Instant now = Instant.now()
         def bodyMap = new DefaultClaims()
             .setIssuer(TEST_ISSUER)

--- a/impl/src/test/groovy/com/okta/jwt/impl/jjwt/JjwtIdTokenVerifierTest.groovy
+++ b/impl/src/test/groovy/com/okta/jwt/impl/jjwt/JjwtIdTokenVerifierTest.groovy
@@ -15,11 +15,12 @@
  */
 package com.okta.jwt.impl.jjwt
 
+import com.okta.commons.lang.Classes
 import com.okta.jwt.JwtVerificationException
 import com.okta.jwt.impl.TestUtil
 import io.jsonwebtoken.*
 import io.jsonwebtoken.impl.DefaultClaims
-import io.jsonwebtoken.io.JacksonSerializer
+import io.jsonwebtoken.io.Serializer
 import org.testng.annotations.DataProvider
 import org.testng.annotations.Test
 
@@ -82,7 +83,7 @@ class JjwtIdTokenVerifierTest extends TokenVerifierTestSupport {
 
     @Override
     byte[] defaultFudgedBody() {
-        JacksonSerializer serializer = new JacksonSerializer()
+        Serializer serializer = Classes.loadFromService(Serializer)
         Instant now = Instant.now()
         def bodyMap = new DefaultClaims()
             .setIssuer(TEST_ISSUER)

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta</groupId>
         <artifactId>okta-parent</artifactId>
-        <version>16</version>
+        <version>17</version>
     </parent>
 
     <groupId>com.okta.jwt</groupId>
@@ -31,8 +31,9 @@
 
     <properties>
         <github.slug>okta/okta-jwt-verifier-java</github.slug>
-        <okhttp.version>3.14.4</okhttp.version>
-        <okta.commons.version>1.2.2</okta.commons.version>
+        <okhttp.version>3.14.9</okhttp.version>
+        <okta.commons.version>1.2.3</okta.commons.version>
+        <jjwt.version>0.11.2</jjwt.version>
     </properties>
 
     <modules>
@@ -48,7 +49,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.10.0</version>
+                <version>2.11.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <github.slug>okta/okta-jwt-verifier-java</github.slug>
         <okhttp.version>3.14.9</okhttp.version>
-        <okta.commons.version>1.2.3</okta.commons.version>
+        <okta.commons.version>1.2.4</okta.commons.version>
         <jjwt.version>0.11.2</jjwt.version>
     </properties>
 


### PR DESCRIPTION
- Jackson to 2.11.1
- Okta Commons - 1.2.4
- JJWT 0.11.2

Also cleaned up dependency scope issue (jjwt-jackson should have been a runtime scope), and hid the fact that jackson was only a transitive dependency
(removed direct dependency on jjwt-jackson in test code as well)

Fixes: okta/okta-commons-java#26