### PR TITLE
Document Android compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ For more information on this project take a look at the following resources:
 
 # Android
 
-Okta JWT Verifier works with Android API 26+. If you have a use case for using this on Android and require compatibility with older Android versions please open an issue.
+Okta JWT Verifier works with Android API 21+.
 
-[Java 8 library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) may be required as Okta JWT Verifier makes use of java 8 features. See the link, or the below example on how to configure it.
+[Java 8 library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) may be required as Okta JWT Verifier makes use of java 8 features. See the link, or the example below on how to configure it.
 
 ```
 android {

--- a/README.md
+++ b/README.md
@@ -91,5 +91,31 @@ For more information on this project take a look at the following resources:
 
 # Android
 
-Okta JWT Verifier works with Android API 26+. If you have a use case for using this on Android and require 
-compatibility with older Android versions please open an issue. 
+Okta JWT Verifier works with Android API 26+. If you have a use case for using this on Android and require compatibility with older Android versions please open an issue.
+
+[Java 8 library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) may be required as Okta JWT Verifier makes use of java 8 features. See the link, or the below example on how to configure it.
+
+```
+android {
+  defaultConfig {
+    // Required when setting minSdkVersion to 20 or lower
+    multiDexEnabled true
+  }
+
+  compileOptions {
+    // Flag to enable support for the new language APIs
+    coreLibraryDesugaringEnabled true
+    // Sets Java compatibility to Java 8
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
+  // For Kotlin projects
+  kotlinOptions {
+    jvmTarget = "1.8"
+  }
+}
+
+dependencies {
+  coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.10'
+}
+```

--- a/README.md
+++ b/README.md
@@ -88,3 +88,8 @@ For more information on this project take a look at the following resources:
 - [Javadocs](https://developer.okta.com/okta-jwt-verifier-java/apidocs/)
 - [Maven Central](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.okta.jwt%22%20a%3A%22okta-jwt-verifier%22)
 - [Working With OAuth 2.0 Tokens](https://developer.okta.com/authentication-guide/tokens/)
+
+# Android
+
+Okta JWT Verifier works with Android API 26+. If you have a use case for using this on Android and require 
+compatibility with older Android versions please open an issue. 

--- a/impl/src/main/java/com/okta/jwt/impl/jjwt/RemoteJwkSigningKeyResolver.java
+++ b/impl/src/main/java/com/okta/jwt/impl/jjwt/RemoteJwkSigningKeyResolver.java
@@ -23,6 +23,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwsHeader;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.SigningKeyResolver;
+import io.jsonwebtoken.io.Decoders;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -32,7 +33,6 @@ import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPublicKeySpec;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -97,6 +97,6 @@ final class RemoteJwkSigningKeyResolver implements SigningKeyResolver {
     }
 
     private BigInteger base64ToBigInteger(String value) {
-        return new BigInteger(1, Base64.getUrlDecoder().decode(value));
+        return new BigInteger(1, Decoders.BASE64URL.decode(value));
     }
 }


### PR DESCRIPTION
Internal Issue: OKTA-233997

The library only works on API 26+ due to usage of java.util.Base64, which wasn't available on Android until API 26.