### PR TITLE
Fix race condition in RemoteJwkSigningKeyResolver#updateKeys

### DIFF
--- a/impl/src/main/java/com/okta/jwt/impl/jjwt/RemoteJwkSigningKeyResolver.java
+++ b/impl/src/main/java/com/okta/jwt/impl/jjwt/RemoteJwkSigningKeyResolver.java
@@ -42,7 +42,7 @@ final class RemoteJwkSigningKeyResolver implements SigningKeyResolver {
     private final URL jwkUri;
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final Map<String, Key> keyMap = new HashMap<>();
+    private Map<String, Key> keyMap = new HashMap<>();
 
     RemoteJwkSigningKeyResolver(URL jwkUri, HttpClient httpClient) {
         this.jwkUri = jwkUri;
@@ -88,8 +88,7 @@ final class RemoteJwkSigningKeyResolver implements SigningKeyResolver {
                     }
                }));
 
-            keyMap.clear();
-            keyMap.putAll(newKeys);
+            keyMap = newKeys;
 
         } catch (IOException e) {
             throw new JwtException("Failed to fetch keys from URL: " + jwkUri, e);

--- a/impl/src/main/java/com/okta/jwt/impl/jjwt/RemoteJwkSigningKeyResolver.java
+++ b/impl/src/main/java/com/okta/jwt/impl/jjwt/RemoteJwkSigningKeyResolver.java
@@ -44,7 +44,7 @@ final class RemoteJwkSigningKeyResolver implements SigningKeyResolver {
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final Object lock = new Object();
-    private Map<String, Key> keyMap = new HashMap<>();
+    private volatile Map<String, Key> keyMap = new HashMap<>();
 
     RemoteJwkSigningKeyResolver(URL jwkUri, HttpClient httpClient) {
         this.jwkUri = jwkUri;


### PR DESCRIPTION
Previously, keyMap could be null for a brief moment, usually on start-up,
leading to a NullPointerException in #getKey