### PR TITLE
Fix compiler warnings about raw types

### DIFF
--- a/impl/src/main/java/com/okta/jwt/impl/jjwt/ClaimsValidator.java
+++ b/impl/src/main/java/com/okta/jwt/impl/jjwt/ClaimsValidator.java
@@ -62,7 +62,7 @@ interface ClaimsValidator {
         @Override
         public void validateClaims(Jws<Claims> jws) {
             Object actual = jws.getBody().get("aud");
-            if (!(actual instanceof Collection && new HashSet((Collection) actual).contains(expectedAudience)
+            if (!(actual instanceof Collection && ((Collection<?>) actual).contains(expectedAudience)
                 || actual instanceof String && actual.equals(expectedAudience))) {
                 throw new IncorrectClaimException(jws.getHeader(), jws.getBody(), "Claim `aud` was invalid, it did not contain the expected value of: "+ expectedAudience);
             }


### PR DESCRIPTION
Collection and HashSet are raw types. Referneces to generic types should be parameterized. Casting to HashSet is not required to check if the collection contains an object.

I believe this is an Obvious Fix in the context of the [CLA](https://developer.okta.com/cla/).