### PR TITLE
Use jjwt version property in integration tests pom

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-api</artifactId>
-            <version>0.10.7</version>
+            <version>${jjwt.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Like in other poms, use a property with jjwt version when adding the dependency.

I believe this is an Obvious Fix in the context of the [CLA](https://developer.okta.com/cla/).


