### PR TITLE
Ignore files generated by Eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 target/
 *.iml
 .idea
+# Eclipse files
+.settings/
+.classpath
+.project


### PR DESCRIPTION
Ignore Eclipse .project and .classpath files. Ignore any files in the .settings folder also created by Eclipse.

I believe this is an Obvious Fix in the context of the [CLA](https://developer.okta.com/cla/).