### PR TITLE
Replace deprecated Jwts.parser() with Jwts.parseBuilder()

### DIFF
--- a/impl/src/main/java/com/okta/jwt/impl/jjwt/TokenVerifierSupport.java
+++ b/impl/src/main/java/com/okta/jwt/impl/jjwt/TokenVerifierSupport.java
@@ -45,10 +45,11 @@ abstract class TokenVerifierSupport {
     }
 
     protected JwtParser parser() {
-         return Jwts.parser()
+         return Jwts.parserBuilder()
                 .setSigningKeyResolver(keyResolver)
                 .requireIssuer(issuer)
-                .setAllowedClockSkewSeconds(leeway.getSeconds());
+                .setAllowedClockSkewSeconds(leeway.getSeconds())
+                .build();
     }
 
     protected Jwt decode(String token, JwtParser parser, ClaimsValidator claimsValidator) throws JwtVerificationException {


### PR DESCRIPTION
`Jwts.parser()` is deprecated. This change fixes the deprecation warning in `TokenVerifierSupport` by replacing the deprecated method with `Jwts.parseBuilder()` as suggested in the javadoc.

I believe this is an [Obvious Fix](https://developer.okta.com/cla/).