### PR TITLE
fix cve

### DIFF
--- a/src/owasp/owasp-suppression.xml
+++ b/src/owasp/owasp-suppression.xml
@@ -39,4 +39,23 @@
         <gav regex="true">^org\.slf4j:jcl-over-slf4j:.*$</gav>
         <cve>CVE-2018-8088</cve>
     </suppress>
+
+    <!-- false positive - see https://github.com/jeremylong/DependencyCheck/issues/3133 
+
+     https://nvd.nist.gov/vuln/detail/CVE-2020-15824
+     https://nvd.nist.gov/vuln/detail/CVE-2020-29582
+    -->
+    <suppress>
+        <notes><![CDATA[ file name: kotlin-stdlib-1.4.10.jar]]></notes>
+        <gav regex="true">^org\.jetbrains\.kotlin:kotlin-stdlib:.*$</gav>
+        <cve>CVE-2020-29582</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[ file name: kotlin-stdlib-common-1.4.0.jar]]></notes>
+        <gav regex="true">^org\.jetbrains\.kotlin:kotlin-stdlib-common:.*$</gav>
+        <cve>CVE-2020-15824</cve>
+        <cve>CVE-2020-29582</cve>
+    </suppress>
+
+    
 </suppressions>


### PR DESCRIPTION
<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.
Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)

```
[ERROR] Failed to execute goal org.owasp:dependency-check-maven:6.1.0:aggregate (default-cli) on project okta-jwt-verifier-parent:
[ERROR]
[ERROR] One or more dependencies were identified with vulnerabilities:
[ERROR]
[ERROR] kotlin-stdlib-1.4.10.jar: CVE-2020-29582
[ERROR] kotlin-stdlib-common-1.4.0.jar: CVE-2020-29582, CVE-2020-15824
[ERROR]
[ERROR] See the dependency-check report for more details.
[ERROR]
[ERROR]
[ERROR] -> [Help 1]
```

## Description
<!-- Add a brief description of the issue. -->

## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
