### PR TITLE
Updates javadoc in DefaultJwt to show where JWT parsing happens

### DIFF
--- a/impl/src/main/java/com/okta/jwt/impl/DefaultJwt.java
+++ b/impl/src/main/java/com/okta/jwt/impl/DefaultJwt.java
@@ -35,9 +35,17 @@ public class DefaultJwt implements Jwt {
 
     private final String tokenValue;
     private final Map<String, Object> claims;
-    private Instant issuedAt;
-    private Instant expiresAt;
+    private final Instant issuedAt;
+    private final Instant expiresAt;
 
+    /**
+     * Creates an instance based on input from an already parsed and validated JWT.
+     * @param tokenValue Original JWT string
+     * @param issuedAt The value from the {@code iat} claim, as an {@link Instant}
+     * @param expiresAt The value from the {@code exp} claim, as an {@link Instant}
+     * @param claims A map of the original claim values in the JWT
+     * @see com.okta.jwt.impl.jjwt.TokenVerifierSupport for actual JWT parsing logic.
+     */
     public DefaultJwt(String tokenValue,
                       Instant issuedAt,
                       Instant expiresAt,


### PR DESCRIPTION
minor code cleanup, issuedAt and expiresAt fields are now final (they only had getters), no breaking changes

## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [x] Documentation
