### PR TITLE
[#116] Add Clock support to parser for unit tests

### DIFF
--- a/api/src/main/java/com/okta/jwt/VerifierBuilderSupport.java
+++ b/api/src/main/java/com/okta/jwt/VerifierBuilderSupport.java
@@ -15,6 +15,7 @@
  */
 package com.okta.jwt;
 
+import java.time.Clock;
 import java.time.Duration;
 
 /**
@@ -97,6 +98,14 @@ public interface VerifierBuilderSupport<B extends VerifierBuilderSupport, R> {
      * @return a reference to the current builder for use in method chaining
      */
     B setRetryMaxElapsed(Duration retryMaxElapsed);
+
+    /**
+     * Sets the {@code clock} the verifier will use for evaluating token expiration.
+     *
+     * @param clock specify an alternate clock, such as fixed or offset to be used during testing
+     * @return a reference to the current builder for use in method chaining
+     */
+    B setClock(Clock clock);
 
     /**
      * Constructs a JWT Verifier.

--- a/impl/src/main/java/com/okta/jwt/impl/jjwt/BaseVerifierBuilderSupport.java
+++ b/impl/src/main/java/com/okta/jwt/impl/jjwt/BaseVerifierBuilderSupport.java
@@ -25,6 +25,7 @@ import io.jsonwebtoken.SigningKeyResolver;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Clock;
 import java.time.Duration;
 import java.util.Objects;
 
@@ -39,6 +40,7 @@ abstract class BaseVerifierBuilderSupport<B extends VerifierBuilderSupport, R> i
     private String proxyPassword = null;
     private int retryMaxAttempts = 2; /* based on SDK spec */
     private Duration retryMaxElapsed = Duration.ofSeconds(10);
+    private Clock clock = Clock.systemDefaultZone();
 
     String getIssuer() {
         return issuer;
@@ -133,6 +135,15 @@ abstract class BaseVerifierBuilderSupport<B extends VerifierBuilderSupport, R> i
         return self();
     }
 
+    public Clock getClock() {
+        return clock;
+    }
+
+    public B setClock(Clock clock) {
+        this.clock = clock;
+        return self();
+    }
+
     @SuppressWarnings("unchecked")
     protected B self() {
         return (B) this;
@@ -184,11 +195,12 @@ abstract class BaseVerifierBuilderSupport<B extends VerifierBuilderSupport, R> i
                 Objects.equals(proxyHost, that.proxyHost) &&
                 Objects.equals(proxyUsername, that.proxyUsername) &&
                 Objects.equals(proxyPassword, that.proxyPassword) &&
-                Objects.equals(retryMaxElapsed, that.retryMaxElapsed);
+                Objects.equals(retryMaxElapsed, that.retryMaxElapsed) &&
+                Objects.equals(clock, that.clock);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(issuer, leeway, connectionTimeout, proxyHost, proxyPort, proxyUsername, proxyPassword, retryMaxAttempts, retryMaxElapsed);
+        return Objects.hash(issuer, leeway, connectionTimeout, proxyHost, proxyPort, proxyUsername, proxyPassword, retryMaxAttempts, retryMaxElapsed, clock);
     }
 }

--- a/impl/src/main/java/com/okta/jwt/impl/jjwt/JjwtAccessTokenVerifier.java
+++ b/impl/src/main/java/com/okta/jwt/impl/jjwt/JjwtAccessTokenVerifier.java
@@ -20,6 +20,7 @@ import com.okta.jwt.Jwt;
 import com.okta.jwt.JwtVerificationException;
 import io.jsonwebtoken.SigningKeyResolver;
 
+import java.time.Clock;
 import java.time.Duration;
 
 /**
@@ -36,7 +37,17 @@ public class JjwtAccessTokenVerifier extends TokenVerifierSupport
                                    Duration leeway,
                                    SigningKeyResolver signingKeyResolver) {
 
-        super(issuer, leeway, signingKeyResolver);
+        super(issuer, leeway, signingKeyResolver, Clock.systemDefaultZone());
+        this.audience = audience;
+    }
+
+    public JjwtAccessTokenVerifier(String issuer,
+                                   String audience,
+                                   Duration leeway,
+                                   SigningKeyResolver signingKeyResolver,
+                                   Clock clock) {
+
+        super(issuer, leeway, signingKeyResolver, clock);
         this.audience = audience;
     }
 

--- a/impl/src/test/groovy/com/okta/jwt/impl/jjwt/JjwtAccessTokenVerifierFixedClockTest.groovy
+++ b/impl/src/test/groovy/com/okta/jwt/impl/jjwt/JjwtAccessTokenVerifierFixedClockTest.groovy
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.jwt.impl.jjwt
+
+import com.okta.commons.lang.Classes
+import com.okta.jwt.Jwt
+import com.okta.jwt.JwtVerificationException
+import io.jsonwebtoken.JwtBuilder
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SigningKeyResolver
+import io.jsonwebtoken.impl.DefaultClaims
+import io.jsonwebtoken.io.Serializer
+import org.testng.annotations.Test
+
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+import static com.okta.jwt.impl.TestUtil.expect
+
+class JjwtAccessTokenVerifierFixedClockTest extends JjwtAccessTokenVerifierTest {
+    public final static Clock clock =
+            Clock.fixed(Instant.ofEpochSecond(361385454L), ZoneId.systemDefault())
+
+    @Override
+    byte[] defaultFudgedBody() {
+        Serializer serializer = Classes.loadFromService(Serializer)
+        Instant now = clock.instant()
+        def bodyMap = new DefaultClaims()
+            .setIssuer(TEST_ISSUER)
+            .setAudience(TEST_AUDIENCE_ID)
+            .setIssuedAt(Date.from(now))
+            .setNotBefore(Date.from(now))
+            .setExpiration(Date.from(now.plus(1L, ChronoUnit.HOURS)))
+
+        return serializer.serialize(bodyMap)
+    }
+
+    @Override
+    Jwt decodeToken(String token, SigningKeyResolver signingKeyResolver) {
+        JjwtAccessTokenVerifier verifier = new JjwtAccessTokenVerifier(TEST_ISSUER, TEST_AUDIENCE_ID,  Duration.ofSeconds(10L), signingKeyResolver, clock)
+        return verifier.decode(token)
+    }
+
+    @Override
+    JwtBuilder baseJwtBuilder() {
+        Instant now = clock.instant()
+        return Jwts.builder()
+                .setSubject("joe.coder@example.com")
+                .setIssuer(TEST_ISSUER)
+                .setAudience(TEST_AUDIENCE_ID)
+                .setIssuedAt(Date.from(now))
+                .setNotBefore(Date.from(now))
+                .setExpiration(Date.from(now.plus(1L, ChronoUnit.HOURS)))
+                .setHeader(Jwts.jwsHeader().setKeyId(TEST_PUB_KEY_ID))
+    }
+
+    @Test
+    void expiredOverLeeway() {
+        Instant now = clock.instant()
+        expect JwtVerificationException, {
+            buildThenDecodeToken(baseJwtBuilder()
+                    .setExpiration(Date.from(now.minus(11L, ChronoUnit.SECONDS))))
+        }
+    }
+
+    @Test
+    void expiredUnderLeeway() {
+        Instant now = clock.instant()
+        buildThenDecodeToken(baseJwtBuilder()
+                .setExpiration(Date.from(now.minus(8L, ChronoUnit.SECONDS))))
+    }
+
+    @Test
+    void notBeforeUnderLeeway() {
+        Instant now = clock.instant()
+        buildThenDecodeToken(baseJwtBuilder()
+                .setNotBefore(Date.from(now.minus(9L, ChronoUnit.SECONDS))))
+    }
+}

--- a/impl/src/test/groovy/com/okta/jwt/impl/jjwt/JjwtAccessTokenVerifierTest.groovy
+++ b/impl/src/test/groovy/com/okta/jwt/impl/jjwt/JjwtAccessTokenVerifierTest.groovy
@@ -35,7 +35,7 @@ import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.is
 
-class JjwtAccessTokenVerifierTest extends TokenVerifierTestSupport{
+class JjwtAccessTokenVerifierTest extends TokenVerifierTestSupport {
 
     final static String TEST_AUDIENCE_ID = "test-aud"
 


### PR DESCRIPTION
Added support for specifying a `java.time.Clock` as part of the parser builder, to allow for fixed-timestamp unit tests.

The underlying `JwtParser` has a `setClock` that I used via a `TokenVerifierSupport`

## Issue(s)
[#116](https://github.com/okta/okta-jwt-verifier-java/issues/116)

## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Bugfix
- [x] Enhancement
- [x] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [x] Unit Test(s)
- [ ] Documentation
