### PR TITLE
Remove exclusion of kotlin lib from Okhttp3 which causes NoClassDef error

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -84,16 +84,6 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jetbrains.kotlin</groupId>
-                    <artifactId>kotlin-stdlib-jdk8</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jetbrains.kotlin</groupId>
-                    <artifactId>kotlin-stdlib-common</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- test deps -->


### PR DESCRIPTION


## Issue(s)
https://github.com/okta/okta-jwt-verifier-java/issues/172

## Description
There seems to be an issue with dependencies where upgrading the okta jwtverifier java deals to build failure.
Adding kotlin dependencies or the okttp3 without exclusions solves the issue

```
       <dependency>
            <groupId>com.squareup.okhttp3</groupId>
            <artifactId>okhttp</artifactId>
        </dependency>
```


## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
