### PR TITLE
Bump `com.okta:okta-parent` from 30 to 32

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,30 +12,30 @@ aliases:
 
 jobs:
 
-  jdk8:
-    docker:
-      - image: cimg/openjdk:8.0.322
-    environment:
-        JVM_OPTS: -Xmx3200m
-    steps: *build_steps
-
   jdk11:
     docker:
-      - image: cimg/openjdk:11.0.13
+      - image: cimg/openjdk:11.0.22
     environment:
         JVM_OPTS: -Xmx3200m
     steps: *build_steps
 
   jdk17:
     docker:
-      - image: cimg/openjdk:17.0.4
+      - image: cimg/openjdk:17.0.11
     environment:
         JVM_OPTS: -Xmx3200m
     steps: *build_steps
 
+  jdk21:
+    docker:
+      - image: cimg/openjdk:21.0.2
+    environment:
+      JVM_OPTS: -Xmx3200m
+    steps: *build_steps
+
   snyk-scan:
     docker:
-      - image: cimg/openjdk:17.0.4
+      - image: cimg/openjdk:17.0.11
     steps:
       - checkout
       - run: ./mvnw clean install -Pci -Dmaven.test.skip.exec=true
@@ -49,10 +49,9 @@ jobs:
 workflows:
   build_and_test:
     jobs:
-      - jdk8
       - jdk11
       - jdk17
-  # See OKTA-634407
+      - jdk21
   semgrep:
     jobs:
       - jdk17

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ you an example of how to do this using Okta's JWT Validation library for Java.
 
 > If you are validating access tokens from a Spring application take a look at the [Okta Spring Boot Starter](https://github.com/okta/okta-spring-boot).
 
+### Prerequisites
+
+* Java 11 or later
+
 ## Things you will need
 To validate a JWT, you will need a few different items:
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta</groupId>
         <artifactId>okta-parent</artifactId>
-        <version>30</version>
+        <version>32</version>
     </parent>
 
     <groupId>com.okta.jwt</groupId>


### PR DESCRIPTION
<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.
Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)
<!-- Reference any existing issue(s) here. -->

## Description

- Bump [okta-parent library](https://github.com/okta/okta-java-parent) version from `30` to `32`.
- Updated CCI Images to remove Java 8 (no longer supported) and add Java 21 (latest as of today).
- Updated README with Java 11 or later as the min required Java version for this library.

## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
