### PR TITLE
OKTA-755069: jjwt api setSigningKeyResolver() is deprecated

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -65,7 +65,6 @@
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-impl</artifactId>
             <version>${jjwt.version}</version>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/impl/src/main/java/com/okta/jwt/impl/jjwt/JjwtIdTokenVerifier.java
+++ b/impl/src/main/java/com/okta/jwt/impl/jjwt/JjwtIdTokenVerifier.java
@@ -25,7 +25,7 @@ import io.jsonwebtoken.lang.Objects;
 import java.time.Duration;
 
 /**
- * Classes in this `impl` implementation package may change in NON backward compatible way, and should ONLY be used as
+ * Classes in this `impl` implementation package may change in NON-backward compatible way, and should ONLY be used as
  * a "runtime" dependency.
  */
 public class JjwtIdTokenVerifier extends TokenVerifierSupport
@@ -47,9 +47,9 @@ public class JjwtIdTokenVerifier extends TokenVerifierSupport
        return decode(idToken, parser(), ClaimsValidator.compositeClaimsValidator(
                new ClaimsValidator.ContainsAudienceClaimsValidator(clientId),
                jws -> {
-                   String actualNonce = jws.getBody().get("nonce", String.class);
+                   String actualNonce = jws.getPayload().get("nonce", String.class);
                    if (!Objects.nullSafeEquals(actualNonce, nonce)) {
-                       throw new IncorrectClaimException(jws.getHeader(), jws.getBody(), "nonce", actualNonce, "Claim `nonce` does not match expected value. Note: a `null` nonce is only valid when both the expected and actual values are `null`.");
+                       throw new IncorrectClaimException(jws.getHeader(), jws.getPayload(), "nonce", actualNonce, "Claim `nonce` does not match expected value. Note: a `null` nonce is only valid when both the expected and actual values are `null`.");
                    }
                }));
     }

--- a/impl/src/main/java/com/okta/jwt/impl/jjwt/TokenVerifierSupport.java
+++ b/impl/src/main/java/com/okta/jwt/impl/jjwt/TokenVerifierSupport.java
@@ -57,7 +57,6 @@ abstract class TokenVerifierSupport {
     protected JwtParser buildJwtParser() {
         io.jsonwebtoken.Clock jwtClock = () -> Date.from(clock.instant());
         return Jwts.parser()
-                //.setSigningKeyResolver(keyResolver)
                 .keyLocator(header -> {
                     Claims claims = new DefaultClaimsBuilder()
                             .issuer(issuer)

--- a/impl/src/main/java/com/okta/jwt/impl/jjwt/TokenVerifierSupport.java
+++ b/impl/src/main/java/com/okta/jwt/impl/jjwt/TokenVerifierSupport.java
@@ -18,19 +18,16 @@ package com.okta.jwt.impl.jjwt;
 import com.okta.jwt.Jwt;
 import com.okta.jwt.JwtVerificationException;
 import com.okta.jwt.impl.DefaultJwt;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.JwtHandlerAdapter;
-import io.jsonwebtoken.JwtParser;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.SigningKeyResolver;
-import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.impl.DefaultClaimsBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
 import java.time.Clock;
 import java.time.Duration;
-import java.util.Date;
+import java.util.*;
 
 abstract class TokenVerifierSupport {
 
@@ -64,10 +61,16 @@ abstract class TokenVerifierSupport {
     protected JwtParser buildJwtParser() {
         io.jsonwebtoken.Clock jwtClock = () -> Date.from(clock.instant());
         return Jwts.parser()
-                .setSigningKeyResolver(keyResolver)
+                //.setSigningKeyResolver(keyResolver)
+                .keyLocator(header -> {
+                    Claims claims = new DefaultClaimsBuilder()
+                            .issuer(issuer)
+                            .build();
+                    return keyResolver.resolveSigningKey((JwsHeader) header, claims);
+                })
                 .requireIssuer(issuer)
-                .setAllowedClockSkewSeconds(leeway.getSeconds())
-                .setClock(jwtClock)
+                .clockSkewSeconds(leeway.getSeconds())
+                .clock(jwtClock)
                 .build();
     }
 
@@ -80,9 +83,9 @@ abstract class TokenVerifierSupport {
         try {
             Jws<Claims> jwt = parser.parse(token, new OktaJwtHandler(claimsValidator));
             return new DefaultJwt(token,
-                    jwt.getBody().getIssuedAt().toInstant(),
-                    jwt.getBody().getExpiration().toInstant(),
-                    jwt.getBody());
+                    jwt.getPayload().getIssuedAt().toInstant(),
+                    jwt.getPayload().getExpiration().toInstant(),
+                    jwt.getPayload());
         } catch (JwtException e) {
             throw new JwtVerificationException("Failed to parse token", e);
         }
@@ -121,8 +124,8 @@ abstract class TokenVerifierSupport {
 
            // validate alg
            String alg = jws.getHeader().getAlgorithm();
-           if(!SignatureAlgorithm.RS256.getValue().equals(alg)) {
-               throw new UnsupportedJwtException("JWT Header 'alg' of [" + alg + "] is not supported, only RSA25 signatures are supported");
+           if(!"RS256".equals(alg)) {
+               throw new UnsupportedJwtException("JWT Header 'alg' of [" + alg + "] is not supported, only RSA256 signatures are supported");
            }
 
            claimsValidator.validateClaims(jws);

--- a/impl/src/main/java/com/okta/jwt/impl/jjwt/TokenVerifierSupport.java
+++ b/impl/src/main/java/com/okta/jwt/impl/jjwt/TokenVerifierSupport.java
@@ -20,11 +20,7 @@ import com.okta.jwt.JwtVerificationException;
 import com.okta.jwt.impl.DefaultJwt;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.impl.DefaultClaimsBuilder;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-import java.nio.charset.StandardCharsets;
-import java.security.Key;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.*;


### PR DESCRIPTION
<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.
Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)

#208 

## Description
<!-- Add a brief description of the issue. -->

## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Bugfix
- [x] Enhancement
- [ ] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
