### PR TITLE
OKTA-741803: Add support for SSL Factory and Truststore to HttpClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,18 @@ The Okta JWT Verifier can created via the fluent `JwtVerifiers` class:
  
 [//]: # (method: basicUsage)
 ```java
+// see https://sslcontext-kickstart.com/usage.html for detailed usage options
+SSLFactory sslFactory = SSLFactory.builder()
+        .withIdentityMaterial("identity.jks", "password".toCharArray())
+        .withTrustMaterial("truststore.jks", "password".toCharArray())
+        .build();
 AccessTokenVerifier jwtVerifier = JwtVerifiers.accessTokenVerifierBuilder()
     .setIssuer("https://{yourOktaDomain}/oauth2/default")
     .setAudience("api://default")                   // defaults to 'api://default'
     .setConnectionTimeout(Duration.ofSeconds(1))    // defaults to 1s
     .setRetryMaxAttempts(2)                     // defaults to 2
     .setRetryMaxElapsed(Duration.ofSeconds(10)) // defaults to 10s
-    .setPreloadSigningKeys(true)                // defaults to false
+    .setSslFactory(sslFactory)
     .build();
 ```
 [//]: # (end: basicUsage)

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -29,6 +29,15 @@
 
     <dependencies>
 
+        <dependency>
+            <groupId>io.github.hakky54</groupId>
+            <artifactId>sslcontext-kickstart</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.hakky54</groupId>
+            <artifactId>sslcontext-kickstart-for-pem</artifactId>
+        </dependency>
+
         <!-- test deps -->
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/api/src/main/java/com/okta/jwt/VerifierBuilderSupport.java
+++ b/api/src/main/java/com/okta/jwt/VerifierBuilderSupport.java
@@ -15,6 +15,8 @@
  */
 package com.okta.jwt;
 
+import nl.altindag.ssl.SSLFactory;
+
 import java.time.Clock;
 import java.time.Duration;
 
@@ -106,6 +108,14 @@ public interface VerifierBuilderSupport<B extends VerifierBuilderSupport, R> {
      * @return a reference to the current builder for use in method chaining
      */
     B setClock(Clock clock);
+
+    /**
+     * Sets the {@code sslFactory} the verifier will use for http client.
+     *
+     * @param sslFactory the ssl factory instance to be used by the underlying HTTP client.
+     * @return a reference to the current builder for use in method chaining
+     */
+    B setSslFactory(SSLFactory sslFactory);
 
     /**
      * Sets the {@code preloadSigningKeys} the verifier will use to determine if it needs to prefetch Signing keys into cache at boot time.

--- a/examples/quickstart/src/main/java/com/okta/jwt/example/QuickStartExample.java
+++ b/examples/quickstart/src/main/java/com/okta/jwt/example/QuickStartExample.java
@@ -34,7 +34,6 @@ public class QuickStartExample {
         String audience  = args[1];
         String jwtString = args[2];
 
-
         // 1. build the parser
         AccessTokenVerifier jwtVerifier = JwtVerifiers.accessTokenVerifierBuilder()
                                     .setIssuer(issuerUrl)

--- a/examples/quickstart/src/main/java/com/okta/jwt/example/ReadmeSnippets.java
+++ b/examples/quickstart/src/main/java/com/okta/jwt/example/ReadmeSnippets.java
@@ -17,6 +17,7 @@ package com.okta.jwt.example;
 
 import com.okta.jwt.AccessTokenVerifier;
 import com.okta.jwt.JwtVerifiers;
+import nl.altindag.ssl.SSLFactory;
 
 import java.time.Duration;
 
@@ -29,12 +30,20 @@ import java.time.Duration;
 public class ReadmeSnippets {
 
     private void basicUsage() {
+
+        // See https://sslcontext-kickstart.com/usage.html for detailed usage options
+        SSLFactory sslFactory = SSLFactory.builder()
+                .withIdentityMaterial("identity.jks", "password".toCharArray())
+                .withTrustMaterial("truststore.jks", "password".toCharArray())
+                .build();
+
         AccessTokenVerifier jwtVerifier = JwtVerifiers.accessTokenVerifierBuilder()
             .setIssuer("https://{yourOktaDomain}/oauth2/default")
             .setAudience("api://default")                   // defaults to 'api://default'
             .setConnectionTimeout(Duration.ofSeconds(1))    // defaults to 1s
             .setRetryMaxAttempts(2)                     // defaults to 2
             .setRetryMaxElapsed(Duration.ofSeconds(10)) // defaults to 10s
+            .setSslFactory(sslFactory)                  // set SSL factory
             .build();
     }
 }

--- a/impl/src/main/java/com/okta/jwt/impl/jjwt/BaseVerifierBuilderSupport.java
+++ b/impl/src/main/java/com/okta/jwt/impl/jjwt/BaseVerifierBuilderSupport.java
@@ -22,6 +22,7 @@ import com.okta.jwt.VerifierBuilderSupport;
 import com.okta.jwt.impl.http.HttpClient;
 import com.okta.jwt.impl.http.OktaCommonsHttpClient;
 import io.jsonwebtoken.SigningKeyResolver;
+import nl.altindag.ssl.SSLFactory;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -40,6 +41,7 @@ abstract class BaseVerifierBuilderSupport<B extends VerifierBuilderSupport, R> i
     private String proxyPassword = null;
     private int retryMaxAttempts = 2; /* based on SDK spec */
     private Duration retryMaxElapsed = Duration.ofSeconds(10);
+    private SSLFactory sslFactory;
     private Clock clock = Clock.systemDefaultZone();
     private boolean preloadSigningKeys = false;
 
@@ -145,7 +147,16 @@ abstract class BaseVerifierBuilderSupport<B extends VerifierBuilderSupport, R> i
         return self();
     }
 
-   public boolean getPreloadSigningKeys() {
+    public SSLFactory getSslFactory() {
+        return sslFactory;
+    }
+
+    public B setSslFactory(SSLFactory sslFactory) {
+        this.sslFactory = sslFactory;
+        return self();
+    }
+
+    public boolean getPreloadSigningKeys() {
         return preloadSigningKeys;
     }
 
@@ -196,6 +207,7 @@ abstract class BaseVerifierBuilderSupport<B extends VerifierBuilderSupport, R> i
         httpClientConfiguration.setProxyPort(getProxyPort());
         httpClientConfiguration.setProxyUsername(getProxyUsername());
         httpClientConfiguration.setProxyPassword(getProxyPassword());
+        httpClientConfiguration.setSslFactory(getSslFactory());
         return new OktaCommonsHttpClient(httpClientConfiguration);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <github.slug>okta/okta-jwt-verifier-java</github.slug>
         <okhttp.version>4.12.0</okhttp.version>
-        <okta.commons.version>2.0.0</okta.commons.version>
+        <okta.commons.version>2.0.1</okta.commons.version>
         <jjwt.version>0.12.6</jjwt.version>
     </properties>
 
@@ -105,6 +105,16 @@
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib</artifactId>
                 <version>2.0.20</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.hakky54</groupId>
+                <artifactId>sslcontext-kickstart</artifactId>
+                <version>8.3.7</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.hakky54</groupId>
+                <artifactId>sslcontext-kickstart-for-pem</artifactId>
+                <version>8.3.7</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.
Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)

#183 

This PR is dependent on library change PR at https://github.com/okta/okta-commons-java/pull/211 which needs to be merged first and released before this PR. Until the next version of `okta/okta-commons-java` `2.0.1` is released, this PR's build is expected to fail.

## Description
<!-- Add a brief description of the issue. -->

## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Bugfix
- [x] Enhancement
- [ ] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
