### PR TITLE
OKTA-741804: removing sensitive information from header

### DIFF
--- a/impl/src/main/java/com/okta/jwt/impl/http/OktaCommonsHttpClient.java
+++ b/impl/src/main/java/com/okta/jwt/impl/http/OktaCommonsHttpClient.java
@@ -22,13 +22,11 @@ import com.okta.commons.http.RequestExecutor;
 import com.okta.commons.http.RequestExecutorFactory;
 import com.okta.commons.http.Response;
 import com.okta.commons.http.config.HttpClientConfiguration;
-import com.okta.commons.lang.ApplicationInfo;
 import com.okta.commons.lang.Classes;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.stream.Collectors;
 
 import static com.okta.commons.http.HttpHeaders.USER_AGENT;
 

--- a/impl/src/main/java/com/okta/jwt/impl/http/OktaCommonsHttpClient.java
+++ b/impl/src/main/java/com/okta/jwt/impl/http/OktaCommonsHttpClient.java
@@ -33,9 +33,7 @@ import java.util.stream.Collectors;
 import static com.okta.commons.http.HttpHeaders.USER_AGENT;
 
 public class OktaCommonsHttpClient implements HttpClient {
-    private static final String USER_AGENT_VALUE = ApplicationInfo.get().entrySet().stream()
-            .map(entry -> entry.getKey() + "/" + entry.getValue())
-            .collect(Collectors.joining(" "));
+    private static final String USER_AGENT_VALUE = "okta-jwt-verifier-java";
 
     private final RequestExecutor requestExecutor;
 

--- a/integration-tests/src/test/groovy/com/okta/jwt/it/UserAgentIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/jwt/it/UserAgentIT.groovy
@@ -60,11 +60,10 @@ class UserAgentIT extends KeyServerITSupport {
             RecordedRequest request = server.takeRequest()
             assertThat request.getPath(), is("/oauth2/default/v1/keys")
             assertThat request.headers.get("User-Agent"), allOf(
-                    containsString("okta-jwt-verifier-java/"),
-                    containsString("java/${System.getProperty("java.version")}"),
-                    containsString("${System.getProperty("os.name")}/${System.getProperty("os.version")}"))
+                    containsString("okta-jwt-verifier-java"))
         } finally {
             server.shutdown()
         }
     }
 }
+


### PR DESCRIPTION
<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.
Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)
https://oktainc.atlassian.net/browse/OKTA-741804 - https://github.com/okta/okta-jwt-verifier-java/issues/158
## Description
This PR removes sensitive system information (Java version, OS name/version) from the User-Agent header sent during JWKS resolution. It replaces the dynamic User-Agent with a static, minimal identifier (okta-jwt-verifier-java) to enhance security and prevent potential information disclosure.

Also updates related tests to match the new behaviour.



## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
