### PR TITLE
Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The Okta JWT Verifier can created via the fluent `JwtVerifiers` class:
  
 [//]: # (method: basicUsage)
 ```java
-// see https://sslcontext-kickstart.com/usage.html for detailed usage options
+// see https://ayza.com/usage.html for detailed usage options
 SSLFactory sslFactory = SSLFactory.builder()
         .withIdentityMaterial("identity.jks", "password".toCharArray())
         .withTrustMaterial("truststore.jks", "password".toCharArray())

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -31,11 +31,11 @@
 
         <dependency>
             <groupId>io.github.hakky54</groupId>
-            <artifactId>sslcontext-kickstart</artifactId>
+            <artifactId>ayza</artifactId>
         </dependency>
         <dependency>
             <groupId>io.github.hakky54</groupId>
-            <artifactId>sslcontext-kickstart-for-pem</artifactId>
+            <artifactId>ayza-for-pem</artifactId>
         </dependency>
 
         <!-- test deps -->

--- a/examples/quickstart/src/main/java/com/okta/jwt/example/ReadmeSnippets.java
+++ b/examples/quickstart/src/main/java/com/okta/jwt/example/ReadmeSnippets.java
@@ -31,7 +31,7 @@ public class ReadmeSnippets {
 
     private void basicUsage() {
 
-        // See https://sslcontext-kickstart.com/usage.html for detailed usage options
+        // See https://ayza.com/usage.html for detailed usage options
         SSLFactory sslFactory = SSLFactory.builder()
                 .withIdentityMaterial("identity.jks", "password".toCharArray())
                 .withTrustMaterial("truststore.jks", "password".toCharArray())

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <okhttp.version>3.14.9</okhttp.version>
         <okta.commons.version>2.0.1</okta.commons.version>
         <jjwt.version>0.12.6</jjwt.version>
+        <ayza.version>10.0.0</ayza.version>
     </properties>
 
     <modules>
@@ -108,13 +109,13 @@
             </dependency>
             <dependency>
                 <groupId>io.github.hakky54</groupId>
-                <artifactId>sslcontext-kickstart</artifactId>
-                <version>9.1.0</version>
+                <artifactId>ayza</artifactId>
+                <version>${ayza.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.github.hakky54</groupId>
-                <artifactId>sslcontext-kickstart-for-pem</artifactId>
-                <version>9.1.0</version>
+                <artifactId>ayza-for-pem</artifactId>
+                <version>${ayza.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
The library has been renamed from sslcontext-kickstart to ayza. The latest version is 10.0.0

Sorry for the inconvenience