### PR TITLE
fix: normalise trailing slash in issuer claim comparison (#143)

### DIFF
--- a/impl/src/main/java/com/okta/jwt/impl/jjwt/ClaimsValidator.java
+++ b/impl/src/main/java/com/okta/jwt/impl/jjwt/ClaimsValidator.java
@@ -61,11 +61,35 @@ interface ClaimsValidator {
 
         @Override
         public void validateClaims(Jws<Claims> jws) {
-            Object actual = jws.getBody().get("aud");
+            Object actual = jws.getPayload().get("aud");
             if (!(actual instanceof Collection && ((Collection<?>) actual).contains(expectedAudience)
                 || actual instanceof String && actual.equals(expectedAudience))) {
-                throw new IncorrectClaimException(jws.getHeader(), jws.getBody(), "aud", actual, "Claim `aud` was invalid, it did not contain the expected value of: "+ expectedAudience);
+                throw new IncorrectClaimException(jws.getHeader(), jws.getPayload(), "aud", actual, "Claim `aud` was invalid, it did not contain the expected value of: "+ expectedAudience);
             }
+        }
+    }
+
+    final class IssuerClaimsValidator implements ClaimsValidator {
+
+        private final String expectedIssuer;
+
+        IssuerClaimsValidator(String expectedIssuer) {
+            Assert.notNull(expectedIssuer, "expectedIssuer cannot be null");
+            this.expectedIssuer = expectedIssuer;
+        }
+
+        @Override
+        public void validateClaims(Jws<Claims> jws) {
+            String actualIssuer = jws.getPayload().getIssuer();
+            if (!normalizeIssuer(expectedIssuer).equals(normalizeIssuer(actualIssuer))) {
+                String msg = String.format("Expected %s claim to be: %s, but was: %s.",
+                        Claims.ISSUER, expectedIssuer, actualIssuer);
+                throw new IncorrectClaimException(jws.getHeader(), jws.getPayload(), Claims.ISSUER, actualIssuer, msg);
+            }
+        }
+
+        private static String normalizeIssuer(String issuer) {
+            return issuer != null ? issuer.replaceAll("/$", "") : "";
         }
     }
 }

--- a/impl/src/main/java/com/okta/jwt/impl/jjwt/TokenVerifierSupport.java
+++ b/impl/src/main/java/com/okta/jwt/impl/jjwt/TokenVerifierSupport.java
@@ -63,7 +63,6 @@ abstract class TokenVerifierSupport {
                             .build();
                     return keyResolver.resolveSigningKey((JwsHeader) header, claims);
                 })
-                .requireIssuer(issuer)
                 .clockSkewSeconds(leeway.getSeconds())
                 .clock(jwtClock)
                 .build();
@@ -76,7 +75,10 @@ abstract class TokenVerifierSupport {
         }
 
         try {
-            Jws<Claims> jwt = parser.parse(token, new OktaJwtHandler(claimsValidator));
+            ClaimsValidator fullValidator = ClaimsValidator.compositeClaimsValidator(
+                    new ClaimsValidator.IssuerClaimsValidator(issuer),
+                    claimsValidator);
+            Jws<Claims> jwt = parser.parse(token, new OktaJwtHandler(fullValidator));
             return new DefaultJwt(token,
                     jwt.getPayload().getIssuedAt().toInstant(),
                     jwt.getPayload().getExpiration().toInstant(),

--- a/impl/src/test/groovy/com/okta/jwt/impl/jjwt/TokenVerifierTestSupport.groovy
+++ b/impl/src/test/groovy/com/okta/jwt/impl/jjwt/TokenVerifierTestSupport.groovy
@@ -102,6 +102,16 @@ abstract class TokenVerifierTestSupport {
         }
     }
 
+    @Test
+    void issuerWithTrailingSlashTest() {
+        // A token whose iss claim ends with '/' must be accepted when the configured issuer
+        // has no trailing slash (and vice-versa).  Trailing slashes are normalised before
+        // comparison so that Auth0-style issuers (which always include the slash) work out
+        // of the box. See https://github.com/okta/okta-jwt-verifier-java/issues/143
+        buildThenDecodeToken(baseJwtBuilder()
+                .issuer(TEST_ISSUER + "/"))
+    }
+
     @Test(dataProvider = "invalidIssuers")
     void invalidIssuersTest(Object issuer) {
         expect JwtVerificationException, {
@@ -270,7 +280,6 @@ abstract class TokenVerifierTestSupport {
     @DataProvider(name = "invalidIssuers")
     Object[][] invalidIssuers() {
         return [
-                [TEST_ISSUER + "/"],
                 [TEST_ISSUER + "/other-path"],
                 ["https://Test.Example.com/Issuer"],
         ]


### PR DESCRIPTION
Problem
Auth0 issuers always include a trailing slash in the iss JWT claim (e.g. https://dev-xyz.eu.auth0.com/). [BaseVerifierBuilderSupport.setIssuer()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) intentionally strips any trailing slash from the configured issuer so that the JWKS endpoint URL is constructed correctly. However, [TokenVerifierSupport.buildJwtParser()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) then passed that stripped string to JJWT's .requireIssuer(), which performs an exact string comparison at parse time. This meant the stripped configured issuer could never match a token whose iss claim legitimately carries a trailing slash, producing:

Solution
Replace JJWT's built-in exact-match issuer check with a new [ClaimsValidator.IssuerClaimsValidator](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) that normalises both sides (strips trailing slashes) before comparing. Users can now configure the issuer with or without a trailing slash, and tokens whose iss claim includes or omits a trailing slash will all verify correctly.
